### PR TITLE
Fixed play pause button of player B not being updated, pitchshifter s…

### DIFF
--- a/AudioMixingApp/AudioMixingApp/Effects/PitchshiftEffect.cs
+++ b/AudioMixingApp/AudioMixingApp/Effects/PitchshiftEffect.cs
@@ -8,7 +8,7 @@ namespace AudioMixingApp.Effects
         // The song
         private readonly ISampleProvider _song;
         // The pitch value. 0.5f is one octave down, 1.0f is the normal pitch and 2.0f is an octave up.
-        public float PitchValue;
+        public float PitchValue { get; set; }
         // The pitchshifter. Source: https://github.com/naudio/NAudio/blob/master/Docs/SmbPitchShiftingSampleProvider.md
         private readonly SmbPitchShiftingSampleProvider _pitchShiftingSampleProvider;
         // The waveformat of the song. Contains information like the sample rate of the song, number of bits per sample, number of channels and the audio format.
@@ -32,6 +32,7 @@ namespace AudioMixingApp.Effects
         public void ChangePitchValue(float pitchValue)
         {
             _pitchShiftingSampleProvider.PitchFactor = pitchValue;
+            PitchValue = pitchValue;
         }
 
         /// <summary>

--- a/AudioMixingApp/AudioMixingApp/ViewModels/MixingPageViewModel.cs
+++ b/AudioMixingApp/AudioMixingApp/ViewModels/MixingPageViewModel.cs
@@ -156,6 +156,7 @@ public class MixingPageViewModel : INotifyPropertyChanged
         _timer.Elapsed += (sender, eventArgs) =>
         {
             if (PauseSliderUpdatesA) return;
+            if (PauseSliderUpdatesB) return;
 
             int currentTime = (int)player.PlayingSong.CurrentTime.TotalSeconds;
             string currentTimeString = player.PlayingSong.CurrentTime.ToString(@"hh\:mm\:ss");

--- a/AudioMixingApp/AudioMixingApp/Views/EffectPage.xaml.cs
+++ b/AudioMixingApp/AudioMixingApp/Views/EffectPage.xaml.cs
@@ -16,6 +16,7 @@ public partial class EffectPage : ContentPage
         ((EffectPageViewModel)BindingContext).MidValue = _player.Equalizer.MidValue;
         ((EffectPageViewModel)BindingContext).LowValue = _player.Equalizer.LowValue;
         ((EffectPageViewModel)BindingContext).FlangerFactor = _player.Flanger.FlangerFactor;
+        ((EffectPageViewModel)BindingContext).PitchValue = _player.Pitchshifter.PitchValue;
         InitializeComponent();
 	}
 

--- a/AudioMixingApp/AudioMixingApp/Views/MixingPage.xaml
+++ b/AudioMixingApp/AudioMixingApp/Views/MixingPage.xaml
@@ -143,7 +143,7 @@
             
             <Slider Grid.Row="2" 
                     Grid.Column="3" 
-                    Grid.ColumnSpan="4" 
+                    Grid.ColumnSpan="3" 
                     HorizontalOptions="Fill"
                     VerticalOptions="Center" 
                     WidthRequest="200"

--- a/AudioMixingApp/AudioMixingApp/Views/MixingPage.xaml.cs
+++ b/AudioMixingApp/AudioMixingApp/Views/MixingPage.xaml.cs
@@ -117,6 +117,12 @@ public partial class MixingPage
     private void PlayButtonB_Clicked(object sender, EventArgs e)
     {
         _viewModel.PlaySoundWithPauseCheck('B');
+
+        ImageButton imageButton = (ImageButton)sender;
+
+        imageButton.Source = _viewModel.GetPlaybackState('B') == PlaybackState.Playing
+            ? _pausedImageSource
+            : _playImageSource;
     }
     
     private void ProgressbarSliderB_OnDragCompleted(object sender, EventArgs e)


### PR DESCRIPTION
…lider is no longer reset when leaving and reentering effects page, player b progressslider now behaves normally when progress is changed by user and changed columnspan of progressslider B to 3, the same as progressslider A.