### PR TITLE
Fixed bug where if one of the progresssliders was moved, the other on…

### DIFF
--- a/AudioMixingApp/AudioMixingApp/ViewModels/MixingPageViewModel.cs
+++ b/AudioMixingApp/AudioMixingApp/ViewModels/MixingPageViewModel.cs
@@ -155,18 +155,15 @@ public class MixingPageViewModel : INotifyPropertyChanged
 
         _timer.Elapsed += (sender, eventArgs) =>
         {
-            if (PauseSliderUpdatesA) return;
-            if (PauseSliderUpdatesB) return;
-
             int currentTime = (int)player.PlayingSong.CurrentTime.TotalSeconds;
             string currentTimeString = player.PlayingSong.CurrentTime.ToString(@"hh\:mm\:ss");
 
-            if (playerChar == 'A')
+            if (playerChar == 'A' && !PauseSliderUpdatesA)
             {
                 CurrentTimeA = currentTime;
                 CurrentTimeStringA = currentTimeString;
             }
-            else
+            else if (playerChar == 'B' && !PauseSliderUpdatesB)
             {
                 CurrentTimeB = currentTime;
                 CurrentTimeStringB = currentTimeString;


### PR DESCRIPTION
…e would stop moving and resume after the progresssider was released.